### PR TITLE
fixed the admin constraint in viewing edit button

### DIFF
--- a/app/templates/view.html
+++ b/app/templates/view.html
@@ -44,7 +44,8 @@ Full information about the selected unit.
                 <li>No learning outcomes defined for this unit.</li>
                 {% endfor %}
             </ul>
-            {% if not current_user.is_anonymous and (current_user.role == UserType.ADMIN or current_user.id == unit.creatorid) %}
+
+            {% if current_user.is_authenticated and (current_user.role.value == "admin" or current_user.id == unit.creatorid) %}
             <!-- Edit buttons -->
             <div class="mt-3">
                 <!-- Edit Unit button -->


### PR DESCRIPTION
Tried to run the code and noticed the edit button did not appear in view.html even when user is logged in as admin.
fixed the old if condition with:

{% if current_user.is_authenticated and (current_user.role.value == "admin" or current_user.id == unit.creatorid) %}

it works now